### PR TITLE
sourceTitle and sourceUrl may not exist for manually saved URLs

### DIFF
--- a/SaveAllEntries.js
+++ b/SaveAllEntries.js
@@ -9,8 +9,8 @@ let convertEntries = () => {
       url: element.querySelector("a:not(.entry__source)").href,
       summary: element.querySelector(".EntrySummary").innerText,
       time: regExpLiteral.exec(element.querySelector("span.ago").title)[1],
-      sourceTitle: element.querySelector(".entry__source").innerText,
-      sourceUrl: element.querySelector(".entry__source").href,
+      sourceTitle: element.querySelector(".entry__source")?.innerText,
+      sourceUrl: element.querySelector(".entry__source")?.href,
     });
   });
   return result;


### PR DESCRIPTION
sourceTitle and sourceUrl may not exist for manually saved URLs, in which case TypeErrors will be thrown; use the optional chaining (?.) operator to avoid such errors.